### PR TITLE
feat: prompt user for workspace name

### DIFF
--- a/src/actions/start/start.action.ts
+++ b/src/actions/start/start.action.ts
@@ -185,7 +185,11 @@ export default class StartAction extends Action {
     this.logger.info(
       'Replacing instances of HomePage with HomePageComponent...',
     );
-    replaceInFiles(featureLibPath, 'HomePage', 'HomePageComponent');
+    replaceInFiles({
+      dir: featureLibPath,
+      searchStr: 'HomePage',
+      replaceStr: 'HomePageComponent',
+    });
   }
 
   private updateImportPaths(workspace: string) {


### PR DESCRIPTION
- prompt user for workspace name
- validate workspace name
- replaceInFiles to be more typesafe by making it harder to accidentally switch searchStr and replaceStr
- default to template name for workspace name
- replace workspace name in template to the one provided by user

Closes #26

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/futurizeworld/mantis-cli/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #26 


## What is the new behavior?

The user is prompted for the workspace name when `mantis-app init` is run.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
