### PR TITLE
fix(pnpm): support what pnpm resolves after install

### DIFF
--- a/templates/mantis-todo/apps/web-client/src/app/components/todo-list/todo-list.component.ts
+++ b/templates/mantis-todo/apps/web-client/src/app/components/todo-list/todo-list.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  HostBinding,
+  OnInit,
+} from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { TodosService, Todo, CreateTodo } from '../../services/todos.service';
 import { TodoItemComponent } from '../todo-item/todo-item.component';
@@ -10,13 +15,10 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [TodoItemComponent, AddTodoComponent, CommonModule],
   templateUrl: './todo-list.component.html',
-  styles: `
-    :host {
-      width: 100%;
-    }
-  `,
 })
 export class TodoListComponent implements OnInit {
+  @HostBinding('class')
+  readonly hostClass = 'w-full';
   todos$ = new BehaviorSubject<Todo[]>([]);
 
   constructor(

--- a/templates/mantis-todo/package.json
+++ b/templates/mantis-todo/package.json
@@ -80,7 +80,7 @@
     "prettier-plugin-tailwindcss": "^0.5.12",
     "storybook": "^8.0.2",
     "tailwindcss": "^3.0.2",
-    "typescript": "^5.4.4",
+    "typescript": "~5.4.4",
     "vite": "^5.2.8",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^1.3.1"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mantis-apps/mantis-cli/blob/master/CONTRIBUTING.md
- [ ] All code passes linting (`npm run lint:all`) and formatting (`npm run format:all`) checks
- [ ] Docs have been added / updated if relevant

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Typescript would resolve to a version not supported by the angular compiler and angular had a hard time with `:host` styles when installing with pnpm.

Issue Number: N/A

## What is the new behavior?

Pin typescript to `~5.4.4` and use `@HostBinding` instead of `:host`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
